### PR TITLE
fix(charts): eliminate debounce flicker in useObserveXAxisHeights

### DIFF
--- a/packages/charts/src/hooks/useObserveXAxisHeights.ts
+++ b/packages/charts/src/hooks/useObserveXAxisHeights.ts
@@ -1,48 +1,61 @@
-import { debounce } from '@ui5/webcomponents-react-base/internal/utils';
+import { useIsomorphicLayoutEffect } from '@ui5/webcomponents-react-base/internal/hooks';
 import type { RefObject } from 'react';
 import { useEffect, useRef, useState } from 'react';
 
 const defaultAxisHeight = 30;
 
+function measure(container: Element | null, axisCount: number, prevHeightsRef: React.RefObject<number[]>) {
+  const heights = Array(axisCount).fill(defaultAxisHeight);
+  container?.querySelectorAll<SVGGraphicsElement>('.xAxis').forEach((xAxis, index) => {
+    const height = xAxis?.getBBox()?.height;
+    if (height > defaultAxisHeight) {
+      heights[index] = height;
+    }
+  });
+
+  const prev = prevHeightsRef.current;
+  const same = prev.length === heights.length && prev.every((v, i) => v === heights[i]);
+  if (!same) {
+    prevHeightsRef.current = heights;
+    return heights;
+  }
+  return null;
+}
+
 export const useObserveXAxisHeights = (chartRef: RefObject<SVGElement>, axisCount) => {
   const [xAxisHeights, setXAxisHeights] = useState(Array(axisCount).fill(defaultAxisHeight));
-  const mostRecentXAxisHeights = useRef<number[]>(xAxisHeights);
+  const prevHeightsRef = useRef(xAxisHeights);
 
-  useEffect(() => {
-    const debouncedObserverFn = debounce(() => {
-      const defaultHeights = Array(axisCount).fill(defaultAxisHeight);
-      chartRef.current?.querySelectorAll<SVGGraphicsElement>('.xAxis').forEach((xAxis, index) => {
-        const currentAxisHeight = xAxis?.getBBox()?.height;
-        if (currentAxisHeight > 30) {
-          defaultHeights[index] = currentAxisHeight;
-        }
-      });
-
-      const arraysHaveTheSameLength = mostRecentXAxisHeights.current.length === defaultHeights.length;
-      const arrayContentIsIdentical = mostRecentXAxisHeights.current.every(
-        (value, index) => defaultHeights[index] === value,
-      );
-      if (!(arraysHaveTheSameLength && arrayContentIsIdentical)) {
-        mostRecentXAxisHeights.current = defaultHeights;
-        setXAxisHeights(defaultHeights);
-      }
-    }, 75);
-    const mutationObserver = new MutationObserver(debouncedObserverFn);
-
-    if (chartRef.current) {
-      mutationObserver.observe(chartRef.current, {
-        characterData: false,
-        characterDataOldValue: false,
-        attributes: false,
-        childList: true,
-        subtree: true,
-      });
+  // Synchronous measurement after each of our own commits.
+  useIsomorphicLayoutEffect(() => {
+    const result = measure(chartRef.current, axisCount, prevHeightsRef);
+    if (result) {
+      setXAxisHeights(result);
     }
-    return () => {
-      debouncedObserverFn.cancel();
-      mutationObserver.disconnect();
-    };
-  }, [chartRef, setXAxisHeights, mostRecentXAxisHeights]);
+  });
+
+  // MutationObserver to catch chart content appearing from ResponsiveContainer's
+  // internal re-render and CartesianAxis's componentDidMount re-render.
+  useEffect(() => {
+    const container = chartRef.current;
+    if (!container) {
+      return;
+    }
+
+    const observer = new MutationObserver(() => {
+      const result = measure(container, axisCount, prevHeightsRef);
+      if (result) {
+        setXAxisHeights(result);
+      }
+    });
+    observer.observe(container, {
+      attributes: false,
+      childList: true,
+      subtree: true,
+    });
+
+    return () => observer.disconnect();
+  }, [chartRef, axisCount]);
 
   return xAxisHeights;
 };

--- a/packages/charts/src/hooks/useObserveXAxisHeights.ts
+++ b/packages/charts/src/hooks/useObserveXAxisHeights.ts
@@ -2,9 +2,13 @@ import { useIsomorphicLayoutEffect } from '@ui5/webcomponents-react-base/interna
 import type { RefObject } from 'react';
 import { useEffect, useRef, useState } from 'react';
 
+// recharts default axis height -> is changed when labels are rotated
 const defaultAxisHeight = 30;
 
-function measure(container: Element | null, axisCount: number, prevHeightsRef: React.RefObject<number[]>) {
+/**
+ * Measure x-axis height(s) - defaults to `defaultAxisHeight`
+ */
+function measure(container: Element | null, axisCount: number, prevHeightsRef: RefObject<number[]>) {
   const heights = Array(axisCount).fill(defaultAxisHeight);
   container?.querySelectorAll<SVGGraphicsElement>('.xAxis').forEach((xAxis, index) => {
     const height = xAxis?.getBBox()?.height;
@@ -13,12 +17,13 @@ function measure(container: Element | null, axisCount: number, prevHeightsRef: R
     }
   });
 
-  const prev = prevHeightsRef.current;
-  const same = prev.length === heights.length && prev.every((v, i) => v === heights[i]);
+  const prevHeights = prevHeightsRef.current;
+  const same = prevHeights.length === heights.length && prevHeights.every((value, index) => value === heights[index]);
   if (!same) {
     prevHeightsRef.current = heights;
     return heights;
   }
+  // no change
   return null;
 }
 
@@ -26,7 +31,7 @@ export const useObserveXAxisHeights = (chartRef: RefObject<SVGElement>, axisCoun
   const [xAxisHeights, setXAxisHeights] = useState(Array(axisCount).fill(defaultAxisHeight));
   const prevHeightsRef = useRef(xAxisHeights);
 
-  // Synchronous measurement after each of our own commits.
+  // check on every render if height changed
   useIsomorphicLayoutEffect(() => {
     const result = measure(chartRef.current, axisCount, prevHeightsRef);
     if (result) {
@@ -34,8 +39,7 @@ export const useObserveXAxisHeights = (chartRef: RefObject<SVGElement>, axisCoun
     }
   });
 
-  // MutationObserver to catch chart content appearing from ResponsiveContainer's
-  // internal re-render and CartesianAxis's componentDidMount re-render.
+  // check on every component DOM subtree change (catches internal rerender)
   useEffect(() => {
     const container = chartRef.current;
     if (!container) {

--- a/packages/charts/src/hooks/useObserveXAxisHeights.ts
+++ b/packages/charts/src/hooks/useObserveXAxisHeights.ts
@@ -1,5 +1,5 @@
 import { useIsomorphicLayoutEffect } from '@ui5/webcomponents-react-base/internal/hooks';
-import type { RefObject } from 'react';
+import type { MutableRefObject, RefObject } from 'react';
 import { useEffect, useRef, useState } from 'react';
 
 // recharts default axis height -> is changed when labels are rotated
@@ -8,7 +8,7 @@ const defaultAxisHeight = 30;
 /**
  * Measure x-axis height(s) - defaults to `defaultAxisHeight`
  */
-function measure(container: Element | null, axisCount: number, prevHeightsRef: RefObject<number[]>) {
+function measure(container: Element | null, axisCount: number, prevHeightsRef: MutableRefObject<number[]>) {
   const heights = Array(axisCount).fill(defaultAxisHeight);
   container?.querySelectorAll<SVGGraphicsElement>('.xAxis').forEach((xAxis, index) => {
     const height = xAxis?.getBBox()?.height;


### PR DESCRIPTION
This PR eliminates the visible feedback-loop when initially rendering charts. 
Although the change increases the number of measurement calls in some cases, the cost is negligible, as when the x-axis container size didn't change the call is a no-op.

