### PR TITLE
refactor(charts): remove useless conditional in onDataPointClickInternal

### DIFF
--- a/packages/charts/src/components/PieChart/index.tsx
+++ b/packages/charts/src/components/PieChart/index.tsx
@@ -177,7 +177,7 @@ const PieChart = forwardRef<HTMLDivElement, PieChartProps>((props, ref) => {
 
   const onDataPointClickInternal = useCallback(
     (payload, dataIndex, event) => {
-      if (payload && payload && typeof onDataPointClick === 'function') {
+      if (payload && typeof onDataPointClick === 'function') {
         onDataPointClick(
           enrichEventWithDetails(event, {
             value: payload.value,


### PR DESCRIPTION
To fix this, remove the duplicated `payload` operand in the `if` guard inside `onDataPointClickInternal`.  
The best minimal, behavior-preserving fix is:

- Keep the null/truthy guard for `payload`.
- Keep the function-type guard for `onDataPointClick`.
- Delete only the duplicated `payload &&`.

This change should be made in `packages/charts/src/components/PieChart/index.tsx` at the `onDataPointClickInternal` callback (around line 180 in the snippet). No imports, new methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._