### PR TITLE
refactor(ObjectPage): remove unless conditional

### DIFF
--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -769,7 +769,7 @@ const ObjectPage = forwardRef<ObjectPageDomRef, ObjectPagePropTypes>((props, ref
             }}
           >
             <ObjectPageAnchorBar
-              headerContentVisible={headerArea && headerCollapsed !== true}
+              headerContentVisible={headerCollapsed !== true}
               hidePinButton={!!hidePinButton}
               headerPinned={headerPinned}
               accessibilityAttributes={accessibilityAttributes?.objectPageAnchorBar}


### PR DESCRIPTION
To fix this, remove the redundant `headerArea &&` in the `headerContentVisible` prop passed to `ObjectPageAnchorBar`, since the entire block is already guarded by `headerArea && titleArea`.

Best single fix (no functionality change):
- In `packages/main/src/components/ObjectPage/index.tsx`, inside the `ObjectPageAnchorBar` JSX props (around line 772), change:
  - `headerContentVisible={headerArea && headerCollapsed !== true}`
  - to
  - `headerContentVisible={headerCollapsed !== true}`

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._