### PR TITLE
refactor(AnalyticalTable - useToggleRowExpand): remove useless conditional

### DIFF
--- a/packages/main/src/components/AnalyticalTable/hooks/useToggleRowExpand.ts
+++ b/packages/main/src/components/AnalyticalTable/hooks/useToggleRowExpand.ts
@@ -21,7 +21,7 @@ const getToggleRowExpandedProps = (
     }
 
     let column = null;
-    if (!isTreeTable && (!renderRowSubComponent || (renderRowSubComponent && alwaysShowSubComponent))) {
+    if (!isTreeTable && (!renderRowSubComponent || alwaysShowSubComponent)) {
       if (!manualGroupBy) {
         column = row.cells.find((cell) => cell.column.id === row.groupByID)?.column;
       } else {


### PR DESCRIPTION
To fix this without changing functionality, simplify the boolean condition in `getToggleRowExpandedProps` at line 24 by removing the redundant `renderRowSubComponent && ...` branch.

General approach:
- Replace logically redundant boolean expressions with their minimal equivalent form.
- Keep behavior identical while making intent explicit and avoiding static-analysis warnings.

Best concrete fix in this file:
- In `packages/main/src/components/AnalyticalTable/hooks/useToggleRowExpand.ts`, change:
  - `(!renderRowSubComponent || (renderRowSubComponent && alwaysShowSubComponent))`
  - to
  - `(!renderRowSubComponent || alwaysShowSubComponent)`

No imports, helper methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._