### PR TITLE
refactor(ObjectPageSubSection): replace identical-operator

### DIFF
--- a/packages/main/src/components/ObjectPageSubSection/index.tsx
+++ b/packages/main/src/components/ObjectPageSubSection/index.tsx
@@ -120,7 +120,7 @@ const ObjectPageSubSection = forwardRef<HTMLDivElement, ObjectPageSubSectionProp
         ) : (
           <span aria-hidden="true" className={classNames.spacer} />
         )}
-        {actions && actions}
+        {actions}
       </FlexBox>
       <div className={classNames.subSectionContent} data-component-name="ObjectPageSubSectionContent">
         {children}


### PR DESCRIPTION
To fix this without changing functionality, remove the redundant logical conjunction and render `actions` directly.

- **General approach:** replace identical-operand boolean short-circuit expressions (`x && x`) with the single operand (`x`) when used in JSX output.
- **Best fix here:** in `packages/main/src/components/ObjectPageSubSection/index.tsx`, update line 123 from `{actions && actions}` to `{actions}`.
- **Why safe:** in React rendering, `null`, `undefined`, and `false` are not rendered. Rendering `{actions}` directly keeps behavior equivalent for valid `ReactNode` values while eliminating the redundant expression.
- **No imports, methods, or new definitions** are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._