### PR TITLE
refactor(MessageView): fix for Useless conditional

### DIFF
--- a/packages/main/src/components/MessageView/index.tsx
+++ b/packages/main/src/components/MessageView/index.tsx
@@ -260,7 +260,7 @@ const MessageView = forwardRef<MessageViewDomRef, MessageViewPropTypes>((props, 
                       }
                       return (
                         <Fragment key={groupName}>
-                          {groupName && <ListItemGroup headerText={groupName}>{items}</ListItemGroup>}
+                          <ListItemGroup headerText={groupName}>{items}</ListItemGroup>
                         </Fragment>
                       );
                     })


### PR DESCRIPTION
To fix this without changing behavior, remove the redundant `groupName &&` check in the JSX where `ListItemGroup` is rendered, since control flow has already excluded falsy `groupName`.

Best single change:
- In `packages/main/src/components/MessageView/index.tsx`, inside the `groupedMessages.map` callback, replace:
  - `{groupName && <ListItemGroup headerText={groupName}>{items}</ListItemGroup>}`
  with:
  - `<ListItemGroup headerText={groupName}>{items}</ListItemGroup>`

This preserves functionality exactly while eliminating the always-true conditional that CodeQL reports.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._