### PR TITLE
chore(coverage): only collect coverage from relevant files

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,24 +2,6 @@ import codeCoverageTask from '@cypress/code-coverage/task';
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
-  env: {
-    codeCoverage: {
-      exclude: [
-        'cypress/**',
-        '**/src/interfaces/*',
-        '**/src/enums/*',
-        '**/*.stories.tsx',
-        '**/*.test.{ts,tsx}',
-        '**/*.module.css.ts',
-        '**/node_modules/**',
-        '**/dist/**',
-        'packages/*/src/index.ts',
-        'packages/main/src/components/AnalyticalTable/types/*',
-        'packages/main/src/webComponents/**',
-        'packages/charts/src/resources/**',
-      ],
-    },
-  },
   component: {
     setupNodeEvents(on, config) {
       codeCoverageTask(on, config);

--- a/package.json
+++ b/package.json
@@ -133,6 +133,20 @@
     "temp-dir": "temp/.nyc_output",
     "reporter": [
       "lcov"
+    ],
+    "exclude": [
+      "cypress/**",
+      "**/src/interfaces/*",
+      "**/src/enums/*",
+      "**/*.stories.tsx",
+      "**/*.test.{ts,tsx}",
+      "**/*.module.css.ts",
+      "**/node_modules/**",
+      "**/dist/**",
+      "packages/*/src/index.ts",
+      "packages/main/src/components/AnalyticalTable/types/*",
+      "packages/main/src/webComponents/**",
+      "packages/charts/src/resources/**"
     ]
   },
   "packageManager": "yarn@4.14.1"


### PR DESCRIPTION
`nyc` strips the `./` prefix before glob-matching, while Cypress's submission-time filter doesn't, so the same `**/...` patterns now actually exclude `./`-prefixed paths like `dist/json-imports/i18n.js`.