### PR TITLE
fix(ObjectPage): re-expand header on tab switch in IconTabBar mode

### DIFF
--- a/packages/main/src/components/ObjectPage/ObjectPage.cy.tsx
+++ b/packages/main/src/components/ObjectPage/ObjectPage.cy.tsx
@@ -1931,6 +1931,36 @@ describe('ObjectPage', () => {
     cy.findByText('Custom Header Section Two').should('not.be.visible');
     cy.findByText('Subsection1').should('be.visible');
   });
+
+  it('IconTabBar: header re-expands after tab switch when header was collapsed by scrolling', () => {
+    cy.viewport(1440, 900);
+    cy.mount(
+      <ObjectPage
+        data-testid="op"
+        titleArea={DPTitle}
+        headerArea={DPContent}
+        mode={ObjectPageMode.IconTabBar}
+        style={{ height: '100vh', scrollBehavior: 'auto' }}
+      >
+        <ObjectPageSection key="s1" id="s1" titleText="Section 1">
+          <div style={{ height: '2000px', background: 'lightblue' }}>section 1 content</div>
+        </ObjectPageSection>
+        <ObjectPageSection key="s2" id="s2" titleText="Section 2">
+          <div style={{ height: '2000px', background: 'lightyellow' }}>section 2 content</div>
+        </ObjectPageSection>
+      </ObjectPage>,
+    );
+    cy.wait(50);
+
+    // scroll down far enough to collapse the header
+    cy.findByTestId('op').scrollTo(0, 800);
+    cy.get('[data-component-name="ObjectPageHeaderContent"]').should('not.be.visible');
+
+    // switch tabs — header should re-expand and scroll should reset to top
+    cy.get('[ui5-tabcontainer]').findUi5TabByText('Section 2').click();
+    cy.wait(600);
+    cy.get('[data-component-name="ObjectPageHeaderContent"]').should('be.visible');
+  });
 });
 
 const DPTitle = (

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -322,9 +322,9 @@ const ObjectPage = forwardRef<ObjectPageDomRef, ObjectPagePropTypes>((props, ref
       }
       return newSelectionSectionId;
     });
-    // Reset scroll for section swap; scrollTimeout preserves current header collapsed/expanded state.
     if (mode === ObjectPageMode.IconTabBar) {
       scrollTimeout.current = performance.now() + 500;
+      setHeaderCollapsedInternal(false);
       objectPageRef.current?.scrollTo({ top: 0 });
     }
     setTabSelectId(newSelectionSectionId);
@@ -897,8 +897,7 @@ const ObjectPage = forwardRef<ObjectPageDomRef, ObjectPagePropTypes>((props, ref
             style={{
               height:
                 ((headerCollapsed && !headerPinned) || scrolledHeaderExpanded) &&
-                !toggledCollapsedHeaderWasVisible &&
-                !(mode === ObjectPageMode.IconTabBar && scrollTimeout.current >= performance.now())
+                !toggledCollapsedHeaderWasVisible
                   ? `${headerContentHeight}px`
                   : 0,
             }}


### PR DESCRIPTION
**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist

- [x] Reviewed the [Contributing Guidelines](https://github.com/UI5/webcomponents-react/blob/main/CONTRIBUTING.md)
  - Especially the [How to Contribute](https://github.com/UI5/webcomponents-react/blob/main/CONTRIBUTING.md#contribute-code) section
- [x] [Correct commit message style](https://github.com/UI5/webcomponents-react/blob/main/docs/Guidelines.md#commit-message-style)

## Problem

In `IconTabBar` mode, if the user scrolled down far enough to collapse the header and then switched tabs, the header could not be re-expanded. After `scrollTo({ top: 0 })`, `scrollTop` was `0` and `headerCollapsed` was still `true`, leaving the user with no way to scroll further up to trigger re-expansion.

## Solution

Reset `headerCollapsedInternal` to `false` on tab switch so the header expands alongside `scrollTo({ top: 0 })`. The existing `scrollTimeout` guard in `useObserveHeights` already prevents the programmatic scroll from immediately re-collapsing it.

Also removes the redundant `scrollTimeout` clause from the spacer height condition introduced in #8582, which was suppressing scroll room during the tab switch window and had the same root problem.

Fixes #8803