### PR TITLE
docs: bump Cypress to 16.0.0 in examples/templates vite-ts

### DIFF
--- a/examples/vite-ts/cypress.config.ts
+++ b/examples/vite-ts/cypress.config.ts
@@ -17,5 +17,4 @@ export default defineConfig({
       // implement node event listeners here
     },
   },
-  allowCypressEnv: false,
 });

--- a/examples/vite-ts/package-lock.json
+++ b/examples/vite-ts/package-lock.json
@@ -22,7 +22,7 @@
         "@types/react-dom": "19.2.7",
         "@ui5/webcomponents-cypress-commands": "2.26.0",
         "@vitejs/plugin-react": "6.1.1",
-        "cypress": "15.21.1",
+        "cypress": "16.0.0",
         "eslint": "9.39.5",
         "eslint-plugin-react-hooks": "7.1.1",
         "eslint-plugin-react-refresh": "0.5.6",
@@ -2168,9 +2168,9 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "15.21.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.21.1.tgz",
-      "integrity": "sha512-ogHpHMj0XNlZA5MGzjg8SWHf0eMw9lTwVQRKjpcT1GzNTxNUjwnHA8YCG6nOJ8ThU+XZaUxJgpMYZnJ//8aDaw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-16.0.0.tgz",
+      "integrity": "sha512-/H3zsayGwIGboFIiLWaXxy6ADmCdWy5QjjDBZgslCvjIgYAf1DkZerwAM7wXMPSpfpQ4w+lGjFlmwneRBpg27g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2191,7 +2191,7 @@
         "cli-table3": "0.6.1",
         "commander": "^6.2.1",
         "common-tags": "^1.8.0",
-        "dayjs": "^1.10.4",
+        "dayjs": "^1.11.23",
         "debug": "^4.3.4",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",
@@ -2219,7 +2219,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^20.1.0 || ^22.0.0 || >=24.0.0"
+        "node": "^22.0.0 || ^24.0.0 || >=26.0.0"
       }
     },
     "node_modules/dashdash": {
@@ -2236,9 +2236,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.21",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
-      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "version": "1.11.23",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/examples/vite-ts/package.json
+++ b/examples/vite-ts/package.json
@@ -29,7 +29,7 @@
     "@types/react-dom": "19.2.7",
     "@ui5/webcomponents-cypress-commands": "2.26.0",
     "@vitejs/plugin-react": "6.1.1",
-    "cypress": "15.21.1",
+    "cypress": "16.0.0",
     "eslint": "9.39.5",
     "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-react-refresh": "0.5.6",

--- a/templates/vite-ts/cypress.config.ts
+++ b/templates/vite-ts/cypress.config.ts
@@ -7,5 +7,4 @@ export default defineConfig({
       bundler: 'vite',
     },
   },
-  allowCypressEnv: false,
 });

--- a/templates/vite-ts/package-lock.json
+++ b/templates/vite-ts/package-lock.json
@@ -21,7 +21,7 @@
         "@types/react-dom": "19.2.7",
         "@ui5/webcomponents-cypress-commands": "2.26.0",
         "@vitejs/plugin-react": "6.1.1",
-        "cypress": "15.21.1",
+        "cypress": "16.0.0",
         "eslint": "9.39.5",
         "eslint-plugin-react-hooks": "7.1.1",
         "eslint-plugin-react-refresh": "0.5.6",
@@ -2162,9 +2162,9 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "15.21.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.21.1.tgz",
-      "integrity": "sha512-ogHpHMj0XNlZA5MGzjg8SWHf0eMw9lTwVQRKjpcT1GzNTxNUjwnHA8YCG6nOJ8ThU+XZaUxJgpMYZnJ//8aDaw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-16.0.0.tgz",
+      "integrity": "sha512-/H3zsayGwIGboFIiLWaXxy6ADmCdWy5QjjDBZgslCvjIgYAf1DkZerwAM7wXMPSpfpQ4w+lGjFlmwneRBpg27g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2185,7 +2185,7 @@
         "cli-table3": "0.6.1",
         "commander": "^6.2.1",
         "common-tags": "^1.8.0",
-        "dayjs": "^1.10.4",
+        "dayjs": "^1.11.23",
         "debug": "^4.3.4",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",
@@ -2213,7 +2213,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^20.1.0 || ^22.0.0 || >=24.0.0"
+        "node": "^22.0.0 || ^24.0.0 || >=26.0.0"
       }
     },
     "node_modules/dashdash": {
@@ -2230,9 +2230,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.21",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
-      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "version": "1.11.23",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/templates/vite-ts/package.json
+++ b/templates/vite-ts/package.json
@@ -25,7 +25,7 @@
     "@types/react-dom": "19.2.7",
     "@vitejs/plugin-react": "6.1.1",
     "@ui5/webcomponents-cypress-commands": "2.26.0",
-    "cypress": "15.21.1",
+    "cypress": "16.0.0",
     "eslint": "9.39.5",
     "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-react-refresh": "0.5.6",


### PR DESCRIPTION
#8952 must be merged and realeased first.